### PR TITLE
Remove ambiguous use of ARG_in as <subquery>::TEXT

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A PL/pgSQL function to delete records and foreign-key dependents, regardless of 
 
 - recursively_delete was written not for transactional use-cases, but as an administration tool for special occasions. Performance wasn't the main consideration.
 
-- recursively_delete was developed for PostgreSQL 10.10. It might work for other versions; it might not. (Feedback is welcome.)
+- recursively_delete was developed for PostgreSQL 10.10. It might work for other versions; it might not. (Feedback is welcome!)
 
 ### Signature
 
@@ -44,7 +44,14 @@ Possibilities include:
 - An array of integers: ARRAY[22, 33, 44]
 - A string: 'foo'::TEXT
 - An array of strings: ARRAY['foo', 'bar', 'baz']
-- A subquery: 'SELECT id FROM my_table WHERE on_the_chopping_block = true'::TEXT
+- A uuid: '12345678-90ab-cdef-1234-567890abcdef'::UUID
+- An array of uuids: ARRAY['12345678-90ab-cdef-1234-567890abcdef', '12345678-90ab-cdef-1234-567890abcdef', '12345678-90ab-cdef-1234-567890abcdef']
+- For [composite keys](#delete-three-records-on-a-composite-primary-key), an array of arrays:
+  -  ARRAY[[22, 33], [44, 55], [66, 77]]
+  -  ARRAY[['22', 'foo'], ['33', 'bar'], ['44', 'baz']]
+- A subquery returning one of the above:
+  - (SELECT array_agg(id) FROM my_table WHERE on_the_chopping_block = true)
+  - (SELECT array_agg(ARRAY[id1::TEXT, id2::TEXT, id3::TEXT]) FROM my_table WHERE on_the_chopping_block = true)
 
 *Note that since ANYELEMENT considers untyped text to be type-ambiguous, it's necessary to explicitly type any text value given for ARG_in (e.g. 'foo'::TEXT).*
 
@@ -63,11 +70,15 @@ recursively_delete returns the number of records **explicitly** deleted (not inc
 ##### Preview the deletion of a single record:
 
 ```PLpgSQL
-\set VERBOSITY terse -- Clobber context.
+-- Clobber noisy context in output:
+
+\set VERBOSITY terse
+
+-- Then...
 
 select recursively_delete('users', 4402);
 
--- or --
+-- ...or:
 
 select recursively_delete('users', 4402, false);
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+v0.0.0 - < 2020-06-30
+
+v0.1.0 - 2020-06-030
+
+  * Added explicit support for UUID keys.
+  * Breaking change: Removed ability to pass an SQL string for the ARG_in parameter. An actual subquery serves the purpose better and without ambiguity.

--- a/ddl/func_recursively_delete.sql
+++ b/ddl/func_recursively_delete.sql
@@ -44,9 +44,9 @@ BEGIN
 
   IF array_length(VAR_pk_col_names, 1) = 1 THEN
     CASE pg_typeof(ARG_in)::TEXT
-      WHEN 'character varying', 'text' THEN
-        VAR_in := ARG_in;
-      WHEN 'character varying[]', 'text[]' THEN
+      WHEN 'character varying', 'text', 'uuid' THEN
+        VAR_in := format('%L', ARG_in);
+      WHEN 'character varying[]', 'text[]', 'uuid' THEN
         VAR_in := string_agg(format('%L', ael), ', ') FROM unnest(ARG_in) ael;
       WHEN 'integer' THEN
         VAR_in := ARG_in;
@@ -57,9 +57,7 @@ BEGIN
     END CASE;
   ELSE
     CASE pg_typeof(ARG_in)::TEXT
-      WHEN 'character varying', 'text' THEN
-        VAR_in := ARG_in;
-      WHEN 'character varying[]', 'text[]' THEN
+      WHEN 'character varying[]', 'text[]', 'uuid[]' THEN
         IF array_ndims(ARG_in) = 1 THEN
           VAR_in := format('(%s)', (SELECT string_agg(format('%L', ael), ', ') FROM unnest(ARG_in) ael));
         ELSE


### PR DESCRIPTION
This is a breaking change. Anyone using recursively_delete like this...

SELECT recursively_delete('my_table', 'SELECT id FROM my_table')

...should start using it like this:

SELECT recursively_delete('my_table', (SELECT array_agg(id) FROM my_table))